### PR TITLE
Fixes QMs job EXP req, also adds module comments

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -12,10 +12,10 @@
 	selection_color = "#ffdddd"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 2400
+	exp_requirements = 2400 // NON-MODULE CHANGE
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SECURITY
-	exp_granted_type = EXP_TYPE_COMMAND
+	exp_granted_type = EXP_TYPE_COMMAND // NON-MODULE CHANGE
 
 	outfit = /datum/outfit/job/hos
 	plasmaman_outfit = /datum/outfit/plasmaman/head_of_security

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -8,9 +8,9 @@
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
-	exp_requirements = 2400
-	exp_required_type_department = EXP_TYPE_COMMAND
-	exp_granted_type = EXP_TYPE_COMMAND
+	exp_requirements = 2400 // NON-MODULE CHANGE START
+	exp_required_type_department = EXP_TYPE_SUPPLY
+	exp_granted_type = EXP_TYPE_COMMAND // NON-MODULE CHANGE END
 
 	outfit = /datum/outfit/job/quartermaster
 	plasmaman_outfit = /datum/outfit/plasmaman/cargo

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -14,9 +14,9 @@
 	req_admin_notify = 1
 	minimal_player_age = 7
 	exp_required_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 2400
+	exp_requirements = 2400 // NON-MODULE CHANGE
 	exp_required_type = EXP_TYPE_CREW
-	exp_granted_type = EXP_TYPE_COMMAND
+	exp_granted_type = EXP_TYPE_COMMAND // NON-MODULE CHANGE
 
 	outfit = /datum/outfit/job/rd
 	plasmaman_outfit = /datum/outfit/plasmaman/research_director

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -7,8 +7,8 @@
 	spawn_positions = 2
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
-	exp_requirements = 180
-	exp_required_type = EXP_TYPE_SCIENCE
+	exp_requirements = 180 // NON-MODULE CHANGE
+	exp_required_type = EXP_TYPE_SCIENCE // NON-MODULE CHANGE
 	exp_granted_type = EXP_TYPE_CREW
 	bounty_types = CIV_JOB_ROBO
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -12,7 +12,7 @@
 	minimal_player_age = 7
 	// exp_requirements = 300 // NON-MODULE CHANGE
 	exp_required_type = EXP_TYPE_CREW
-	exp_granted_type = EXP_TYPE_SECURITY
+	exp_granted_type = EXP_TYPE_SECURITY // NON-MODULE CHANGE
 
 	outfit = /datum/outfit/job/security
 	plasmaman_outfit = /datum/outfit/plasmaman/security

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -10,7 +10,7 @@
 	selection_color = "#fff5cc"
 	// exp_requirements = 60 // NON-MODULE CHANGE
 	exp_required_type = EXP_TYPE_CREW
-	exp_granted_type = EXP_TYPE_ENGINEERING
+	exp_granted_type = EXP_TYPE_ENGINEERING // NON-MODULE CHANGE
 
 	outfit = /datum/outfit/job/engineer
 	plasmaman_outfit = /datum/outfit/plasmaman/engineering

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -9,8 +9,8 @@
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	exp_requirements = 300 // NON-MODULE CHANGE
-	exp_required_type = EXP_TYPE_MEDICAL
-	exp_granted_type = EXP_TYPE_MEDICAL
+	exp_required_type = EXP_TYPE_MEDICAL // NON-MODULE CHANGE
+	exp_granted_type = EXP_TYPE_MEDICAL // NON-MODULE CHANGE
 
 	outfit = /datum/outfit/job/virologist
 	plasmaman_outfit = /datum/outfit/plasmaman/viro


### PR DESCRIPTION
What if you wanted to play QM, but I accidentally said EXP_TYPE_COMMAND.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Quartmaster no longer requires command playtime, its now Supply/Cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
