### PR TITLE
[MDB IGNORE] Updates Pubby and Lima with some new doors

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -4669,10 +4669,9 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "bVg" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bVm" = (
@@ -51398,8 +51397,8 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/airlock/hop{
-	name = "Head of Personnel's Office"
+/obj/machinery/door/airlock/hop/glass{
+	name = "Head of Station Pets Room"
 	},
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
@@ -57187,7 +57186,7 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/airlock/hop{
+/obj/machinery/door/airlock/hop/glass{
 	name = "Head of Personnel's Office"
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -5471,7 +5471,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "cpj" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -9244,7 +9244,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/obj/machinery/door/airlock/captain,
+/obj/machinery/door/airlock/captain{
+	name = "Captain's Office"
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "dMi" = (
@@ -10206,6 +10208,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"ekg" = (
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "ekh" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
@@ -10299,7 +10307,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "elU" = (
 /obj/structure/cable,
 /obj/item/clothing/gloves/color/yellow,
@@ -10794,7 +10802,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "ewO" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -11189,7 +11197,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /obj/effect/landmark/navigate_destination,
-/obj/machinery/door/airlock/rd/glass,
+/obj/machinery/door/airlock/rd/glass{
+	name = "Research Directors Office"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "eDO" = (
@@ -11300,7 +11310,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "eFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -11343,7 +11353,7 @@
 "eGA" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "eGC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -11497,7 +11507,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "eJg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -11912,7 +11922,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "ePO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -12152,7 +12162,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "eUB" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/bridge_officer,
@@ -12193,7 +12203,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "eVB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -12666,7 +12676,7 @@
 "fdN" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fdV" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
@@ -12696,7 +12706,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "feg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12714,7 +12724,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fey" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light_switch{
@@ -12765,7 +12775,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "ffa" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -13224,7 +13234,7 @@
 "fnQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fnX" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -13289,10 +13299,10 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fpz" = (
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fpW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -13592,7 +13602,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "ftH" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -13615,7 +13625,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "ftU" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -13918,7 +13928,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fAD" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
@@ -14111,7 +14121,7 @@
 "fFn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "fFq" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -15590,7 +15600,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
-/obj/machinery/door/airlock/captain,
+/obj/machinery/door/airlock/captain{
+	name = "Captains Quarters"
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "gke" = (
@@ -15802,7 +15814,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "gmV" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -16419,7 +16431,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "gyc" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -17270,9 +17282,8 @@
 /turf/open/floor/catwalk_floor,
 /area/service/hydroponics/park)
 "gOW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/control_center)
 "gPn" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -19862,7 +19873,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "hLW" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table,
@@ -20056,10 +20067,6 @@
 /area/maintenance/department/chapel)
 "hQs" = (
 /obj/machinery/status_display/evac/directional/north,
-/obj/machinery/meter{
-	desc = "It doesn't measure anything! Nobody knows why it's here.";
-	name = "Nothing Meter"
-	},
 /turf/open/floor/iron/textured_large,
 /area/engineering/atmos/upper)
 "hQF" = (
@@ -20119,11 +20126,11 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/ten_k/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "hRN" = (
@@ -21609,7 +21616,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ixQ" = (
@@ -24555,7 +24562,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/iron/large,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "jDH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -25271,7 +25278,7 @@
 	},
 /area/hallway/secondary/service)
 "jSw" = (
-/obj/item/crowbar,
+/obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/maintenance/port/lower)
 "jSx" = (
@@ -26459,10 +26466,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "kll" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/hfr_room)
 "klr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27973,7 +27981,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/obj/machinery/door/airlock/qm/glass,
+/obj/machinery/door/airlock/qm/glass{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "kPI" = (
@@ -30081,7 +30091,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/effect/landmark/navigate_destination,
-/obj/machinery/door/airlock/ce,
+/obj/machinery/door/airlock/ce{
+	name = "Chief Engineer's Office"
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "lBt" = (
@@ -33328,7 +33340,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/effect/landmark/navigate_destination/hop,
-/obj/machinery/door/airlock/hop,
+/obj/machinery/door/airlock/hop{
+	name = "Head of Personnel's Office"
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "mJW" = (
@@ -34311,9 +34325,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ncH" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Medical Officer"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34327,6 +34338,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/machinery/door/airlock/cmo/glass{
+	name = "Chief Medical Officer's Office"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "ncP" = (
@@ -35324,7 +35338,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "nvs" = (
 /turf/open/floor/iron,
 /area/security/prison/garden)
@@ -35545,7 +35559,7 @@
 /area/science/test_area)
 "nym" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/space/openspace,
+/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "nyn" = (
 /obj/machinery/door/airlock/command/glass{
@@ -39501,7 +39515,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "oVP" = (
@@ -40273,7 +40287,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "plm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -48114,6 +48128,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"sdi" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "sdl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -48361,7 +48381,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "siC" = (
 /obj/structure/window{
 	dir = 8
@@ -51378,7 +51398,9 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/airlock/hop,
+/obj/machinery/door/airlock/hop{
+	name = "Head of Personnel's Office"
+	},
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
 "tlO" = (
@@ -51986,7 +52008,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "txT" = (
@@ -54138,9 +54160,6 @@
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "upA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
-	},
 /obj/item/wrench,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -54553,7 +54572,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/security/hos,
 /obj/effect/landmark/navigate_destination,
-/obj/machinery/door/airlock/hos,
+/obj/machinery/door/airlock/hos{
+	name = "Head of Security's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "uwH" = (
@@ -55468,7 +55489,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "uQN" = (
@@ -57166,7 +57187,9 @@
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/obj/machinery/door/airlock/hop,
+/obj/machinery/door/airlock/hop{
+	name = "Head of Personnel's Office"
+	},
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "vyL" = (
@@ -57195,7 +57218,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vzc" = (
-/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
 "vzh" = (
@@ -57541,7 +57568,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/obj/machinery/door/airlock/qm/glass,
+/obj/machinery/door/airlock/qm/glass{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "vGZ" = (
@@ -58250,7 +58279,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/control_center)
 "vWs" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -60006,7 +60035,9 @@
 "wEc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/obj/machinery/door/airlock/rd/glass,
+/obj/machinery/door/airlock/rd/glass{
+	name = "Research Directors Office"
+	},
 /turf/open/floor/iron,
 /area/science/server)
 "wEo" = (
@@ -80847,13 +80878,13 @@ dya
 uUR
 dUl
 dya
-fQi
-fQi
+gOW
+gOW
 ePL
 fnQ
 fnQ
-fQi
-fQi
+gOW
+gOW
 fWz
 oIu
 gor
@@ -80864,7 +80895,7 @@ aFp
 oIu
 aFp
 sMw
-kll
+goS
 mNO
 ier
 nCi
@@ -81104,13 +81135,13 @@ rhn
 uVR
 tKh
 dHF
-fQi
+gOW
 ewI
 gxU
 fdN
 fpf
 fAC
-fQi
+gOW
 fWC
 oIu
 hkg
@@ -81121,7 +81152,7 @@ hkg
 oIu
 hkg
 lit
-gOW
+oIu
 ian
 ieb
 ofq
@@ -81361,7 +81392,7 @@ xSq
 uVR
 iNm
 dKN
-fQi
+gOW
 eFH
 pkL
 fef
@@ -81618,13 +81649,13 @@ elU
 min
 qtm
 uGM
-fQi
+gOW
 eVA
 jDB
 sig
 ftF
 hLQ
-fQi
+gOW
 yaM
 alF
 oIu
@@ -81875,13 +81906,13 @@ elU
 min
 wbR
 maO
-fQi
+gOW
 eGA
 eUb
 fex
 ftQ
-fQi
-fQi
+gOW
+gOW
 hRK
 oIu
 tGU
@@ -82137,7 +82168,7 @@ gmH
 vWm
 feW
 coX
-fQi
+gOW
 wCX
 oEC
 oIu
@@ -82389,12 +82420,12 @@ vUe
 qQp
 wDI
 dTe
-fQi
+gOW
 eIV
 fnQ
 nve
 fnQ
-fQi
+gOW
 eeX
 oIu
 oIu
@@ -86021,7 +86052,7 @@ wdo
 fQT
 uTU
 fQT
-wZN
+fQT
 cGJ
 cGJ
 cGJ
@@ -146914,7 +146945,7 @@ vLi
 swT
 vSv
 ven
-vzc
+kll
 eZA
 vSv
 vSv
@@ -147170,7 +147201,7 @@ mJd
 fmT
 uKZ
 vSv
-vzc
+ekg
 xoJ
 vzc
 vSv
@@ -147428,7 +147459,7 @@ vLi
 swT
 vSv
 eZA
-vzc
+sdi
 ven
 vSv
 vSv

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -22311,7 +22311,7 @@
 /area/science/test_area)
 "iLO" = (
 /obj/machinery/computer/security/telescreen/minisat{
-	dir = 8;
+	dir = 1;
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -32019,7 +32019,11 @@
 "mkx" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/fax_machine/recieving_disabled,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen,
+/obj/item/storage/box/silver_ids,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "mli" = (
@@ -42037,12 +42041,8 @@
 /area/maintenance/starboard/lower)
 "pUa" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
 /obj/machinery/light/directional/south,
-/obj/item/pen,
-/obj/item/storage/box/silver_ids,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "pUb" = (
@@ -51257,7 +51257,8 @@
 /area/service/hydroponics/park)
 "tiG" = (
 /obj/machinery/computer/security/telescreen/vault{
-	pixel_x = -32
+	pixel_x = -32;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -3871,13 +3871,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "bEM" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Office"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "bEP" = (
@@ -4297,9 +4297,9 @@
 /area/medical/morgue)
 "bNh" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_one_access_txt = "5;69"
+	name = "Medbay Maintenance"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bNl" = (
@@ -8717,12 +8717,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dAb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dAi" = (
@@ -9026,11 +9025,11 @@
 /area/service/hydroponics)
 "dHi" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Prison Wing"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "dHl" = (
@@ -9152,11 +9151,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig";
+	id_tag = "outerbrig"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "dJK" = (
@@ -9239,15 +9238,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "dMd" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Office"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/captain,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "dMi" = (
@@ -10209,12 +10206,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"ekg" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
 "ekh" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
@@ -10287,13 +10278,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "elJ" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/machinery/door/airlock/security/old{
+	name = "Interrogation"
+	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "elS" = (
@@ -10686,13 +10677,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "euD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	name = "Prisoner Processing"
+	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "euL" = (
@@ -10727,12 +10718,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "evn" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
 /obj/structure/cable,
+/obj/machinery/door/airlock/security/old{
+	name = "Interrogation"
+	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "evG" = (
@@ -11190,9 +11181,6 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "eDH" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director"
-	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -11201,6 +11189,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/rd/glass,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "eDO" = (
@@ -11615,13 +11604,12 @@
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "eKw" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Holding Area"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/hallway/secondary/exit/departure_lounge)
 "eKG" = (
@@ -13107,13 +13095,13 @@
 	},
 /area/maintenance/port/lower)
 "flR" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Visiting Room"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Visiting Room"
+	},
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "fmd" = (
@@ -13378,14 +13366,14 @@
 /turf/open/floor/grass,
 /area/hallway/primary/upper)
 "fqY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig Control"
+	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "fra" = (
@@ -14654,15 +14642,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fPa" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Office"
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "fPd" = (
@@ -14768,11 +14756,11 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig";
+	id_tag = "outerbrig"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "fRu" = (
@@ -15597,14 +15585,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gkc" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/captain,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "gke" = (
@@ -15947,7 +15933,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/old/glass{
 	name = "Prison Wing"
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -16624,7 +16610,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gBS" = (
@@ -17741,10 +17727,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
+	name = "Hydroponics Maintenance"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "gWi" = (
@@ -17758,7 +17744,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gWu" = (
@@ -19124,9 +19110,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "hxY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19136,6 +19119,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Prison Wing"
+	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "hxZ" = (
@@ -19885,10 +19871,10 @@
 /area/maintenance/department/science)
 "hMa" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Firefighting Equipment";
-	req_access_txt = "12"
+	name = "Firefighting Equipment"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "hMg" = (
@@ -23838,13 +23824,13 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "jrb" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Prison Wing"
+	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -24209,14 +24195,14 @@
 /area/ai_monitored/command/nuke_storage)
 "jwV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig"
+	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -24503,7 +24489,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/science/mixing/hallway)
 "jBZ" = (
@@ -27372,11 +27358,11 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig";
+	id_tag = "outerbrig"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "kCv" = (
@@ -27982,14 +27968,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kPA" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/airlock/qm/glass,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "kPI" = (
@@ -28811,7 +28795,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/old/glass{
 	name = "Prison Wing"
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -30091,15 +30075,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/lower)
 "lBq" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/ce,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "lBt" = (
@@ -31471,12 +31453,12 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "mbc" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	name = "Labor Shuttle"
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mbi" = (
@@ -32947,7 +32929,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lower)
 "mBg" = (
@@ -33249,8 +33231,8 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Utilities Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "mHZ" = (
@@ -33340,15 +33322,13 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "mJS" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/effect/landmark/navigate_destination/hop,
+/obj/machinery/door/airlock/hop,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "mJW" = (
@@ -34843,8 +34823,8 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "service maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "nlk" = (
@@ -36389,9 +36369,8 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "nLh" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "nLo" = (
@@ -38432,8 +38411,8 @@
 	name = "Engineering Maintenance"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oAw" = (
@@ -38560,6 +38539,7 @@
 /area/hallway/secondary/command)
 "oDJ" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "oDN" = (
@@ -39456,14 +39436,14 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/auxiliary)
 "oVl" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Firing Range"
+	},
 /turf/open/floor/iron/dark,
 /area/security/range)
 "oVq" = (
@@ -39702,14 +39682,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oZO" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychologist's Office"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
+/obj/machinery/door/airlock/psych,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "oZP" = (
@@ -40774,12 +40752,14 @@
 /area/security/prison/workout)
 "pud" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig"
+	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -41414,10 +41394,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "pHl" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -41428,6 +41404,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
 /obj/effect/landmark/navigate_destination/sec,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig";
+	id_tag = "outerbrig"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pHr" = (
@@ -41484,13 +41464,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pIo" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig Control"
+	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "pIu" = (
@@ -44506,9 +44486,6 @@
 /turf/open/floor/wood,
 /area/service/bar/lower)
 "qNl" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44516,6 +44493,9 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/effect/landmark/navigate_destination/det,
+/obj/machinery/door/airlock/security/old{
+	name = "Detective's Office"
+	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "qNM" = (
@@ -45666,9 +45646,6 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "rhX" = (
-/obj/machinery/door/airlock/command{
-	name = "Bridge Officer's Office"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45676,6 +45653,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/bo,
 /obj/effect/mapping_helpers/airlock/access/any/command/ap,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/corporate{
+	name = "Bridge Officer's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/bridge_officer_office)
 "rii" = (
@@ -48862,9 +48842,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "sra" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48873,6 +48850,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Office"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "srd" = (
@@ -49105,11 +49085,9 @@
 /turf/open/floor/iron/smooth,
 /area/service/hydroponics/park)
 "svr" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychologist's Office"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/psych,
 /turf/open/floor/iron,
 /area/medical/psychology)
 "svs" = (
@@ -49700,7 +49678,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/old/glass{
 	name = "Prison Wing"
 	},
 /turf/open/floor/iron/dark,
@@ -50034,14 +50012,14 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "sKg" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/machinery/door/airlock/security/old{
+	name = "Evidence Storage"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "sKn" = (
@@ -51395,14 +51373,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/command/glass{
-	name = "Ian's Quarters"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/airlock/hop,
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
 "tlO" = (
@@ -53367,9 +53343,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "tZT" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53378,6 +53351,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /obj/structure/cable,
+/obj/machinery/door/airlock/security/old{
+	name = "Brig"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "tZX" = (
@@ -53596,12 +53572,12 @@
 /turf/open/space/openspace,
 /area/space)
 "udL" = (
-/obj/machinery/door/airlock/security{
-	name = "Armory"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
+/obj/machinery/door/airlock/security/old{
+	name = "Armory"
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "udV" = (
@@ -54575,11 +54551,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	name = "Head of Security's Office"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/security/hos,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/hos,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "uwH" = (
@@ -54757,14 +54731,14 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/engine/atmos)
 "uBs" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "laborexit";
-	name = "Labor Shuttle"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	id_tag = "laborexit";
+	name = "Labor Shuttle"
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uBE" = (
@@ -57187,14 +57161,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vyK" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Ian's Quarters"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/airlock/hop,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "vyL" = (
@@ -57566,12 +57538,10 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos/upper)
 "vGI" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/airlock/qm/glass,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "vGZ" = (
@@ -57840,13 +57810,13 @@
 /area/engineering/supermatter/room)
 "vOo" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
+/obj/machinery/door/airlock/security/old{
+	name = "Armory"
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "vOq" = (
@@ -60034,11 +60004,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wEc" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/machinery/door/airlock/rd/glass,
 /turf/open/floor/iron,
 /area/science/server)
 "wEo" = (
@@ -60860,8 +60828,8 @@
 	name = "Utilities Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "wWP" = (
@@ -61586,11 +61554,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xmY" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "xob" = (
@@ -62017,9 +61984,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xul" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62030,6 +61994,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Security Office"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "xun" = (
@@ -62520,7 +62487,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/science/mixing/hallway)
 "xDG" = (
@@ -63479,7 +63446,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lower)
 "xVP" = (
@@ -63768,14 +63735,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "yaC" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Firing Range"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Firing Range"
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "yaM" = (
@@ -111441,7 +111408,7 @@ sAV
 fBT
 khh
 yiR
-ekg
+qig
 iWT
 qig
 itA

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2043,7 +2043,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "awH" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security/old/glass{
 	name = "Labor Camp Shuttle Airlock"
 	},
 /turf/open/floor/iron/dark,
@@ -6536,12 +6536,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"boc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "bod" = (
 /turf/closed/wall,
 /area/science/explab)
@@ -10744,9 +10738,6 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden/monastery)
 "cvp" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig Control"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -10755,6 +10746,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/airlock/security/old{
+	name = "Brig Control"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "cvT" = (
@@ -10945,9 +10939,6 @@
 /turf/closed/wall,
 /area/service/library/lounge)
 "cyG" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10961,6 +10952,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/airlock/hop{
+	name = "Head of Personnel's Office"
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "cyJ" = (
@@ -11878,11 +11872,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance-right"
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
 /area/security/brig)
 "cRM" = (
@@ -12110,15 +12104,15 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "cXo" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	name = "Equipment Room"
+	},
 /turf/open/floor/iron,
 /area/security/lockers)
 "cXA" = (
@@ -15842,10 +15836,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "eFG" = (
-/obj/machinery/door/airlock/command{
-	name = "Bridge Officer's Office";
-	req_one_access_txt = "19; 65"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -15854,6 +15844,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/airlock/corporate{
+	name = "Bridge Officer's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/ap,
+/obj/effect/mapping_helpers/airlock/access/any/command/bo,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/bridge_officer_office)
 "eFN" = (
@@ -16144,12 +16139,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"eNo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "eNq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -17657,9 +17646,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fAZ" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -17669,6 +17655,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/airlock/qm/glass{
+	name = "Quartermasteer's Office"
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "fBp" = (
@@ -18865,14 +18854,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security{
-	name = "Security Access"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	name = "Security Access"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ggN" = (
@@ -19046,9 +19035,6 @@
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
 "gjM" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Office"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -19058,6 +19044,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/obj/machinery/door/airlock/security/old{
+	name = "Security Office"
+	},
 /turf/open/floor/iron,
 /area/security/office)
 "gjT" = (
@@ -20753,6 +20742,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci-ordnance-storage-passthrough"
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gVv" = (
@@ -21547,14 +21539,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "hpR" = (
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old{
+	name = "Equipment Room"
+	},
 /turf/open/floor/iron,
 /area/security/lockers)
 "hqW" = (
@@ -25085,9 +25077,6 @@
 /turf/open/floor/plating,
 /area/service/chapel/monastery)
 "iZy" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -25095,6 +25084,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Interrogation"
+	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "iZV" = (
@@ -26348,12 +26340,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"jHp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "jHs" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -29348,9 +29334,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lcA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/science/server)
+/area/security/lockers)
 "lcD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30596,9 +30581,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
 "lCD" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Office"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -30611,6 +30593,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/captain{
+	name = "Captain's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "lDw" = (
@@ -30906,6 +30891,7 @@
 "lKp" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi,
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "lKH" = (
@@ -33109,9 +33095,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "mIA" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Room"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -33127,6 +33110,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/machinery/door/airlock/security/old{
+	name = "Evidence Room"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "mJd" = (
@@ -33237,24 +33223,8 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "mLe" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance-left"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/turf/open/floor/iron,
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/security/processing/cremation)
 "mLk" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron,
@@ -34158,9 +34128,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "niV" = (
-/obj/machinery/door/airlock/command{
-	name = "Captain's Quarters"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -34169,6 +34136,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/captain{
+	name = "Captains Quarters"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "niX" = (
@@ -35945,9 +35915,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nYW" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
-	},
 /obj/machinery/button/door{
 	id = "prison release";
 	name = "Labor Camp Shuttle Lockdown";
@@ -35958,6 +35925,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Labor Camp Shuttle Airlock"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "nZr" = (
@@ -36791,7 +36761,7 @@
 	departmentType = 5;
 	name = "Security Lockers Requests Console"
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/security/lockers)
 "otr" = (
 /obj/machinery/washing_machine,
@@ -37983,9 +37953,6 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "oVM" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
-	},
 /obj/effect/landmark/navigate_destination/det,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -37995,6 +37962,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Detective's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "oVN" = (
@@ -40170,9 +40140,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pSR" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40183,6 +40150,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/machinery/door/airlock/hos/glass{
+	name = "Head of Security's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "pTs" = (
@@ -40729,7 +40699,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "qib" = (
@@ -40860,10 +40829,6 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "qnf" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Prisoner Transfer Centre"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -40871,6 +40836,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/security/old{
+	name = "Prisoner Transfer Centre"
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "qni" = (
@@ -41808,9 +41776,6 @@
 /turf/open/floor/carpet,
 /area/service/library/lounge)
 "qJQ" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41821,6 +41786,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/machinery/door/airlock/cmo{
+	name = "Chief Medical Officer's Office"
+	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "qJR" = (
@@ -42354,11 +42322,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qYV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Desk"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig Desk"
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "qZg" = (
@@ -44174,9 +44142,6 @@
 /area/hallway/primary/central)
 "rPH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Captain's Office Access"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -44189,6 +44154,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
+/obj/machinery/door/airlock/captain{
+	name = "Captain's Office Access"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "rPM" = (
@@ -44347,16 +44315,15 @@
 /turf/open/floor/iron/white,
 /area/ai_monitored/turret_protected/ai)
 "rTY" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Solutions Room"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/airlock/security/old{
+	name = "Solutions Room"
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rUt" = (
@@ -44514,11 +44481,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Office"
-	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/machinery/door/airlock/rd{
+	name = "Research Director's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "rZB" = (
@@ -46411,9 +46378,6 @@
 /area/hallway/secondary/entry)
 "sUY" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46421,6 +46385,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
+/obj/machinery/door/airlock/ce{
+	name = "Chief Engineer's Office"
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "sVd" = (
@@ -47147,12 +47114,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"tno" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
 "tns" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room"
@@ -48302,9 +48263,6 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/science/explab)
 "tPk" = (
@@ -51138,11 +51096,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance-left"
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
 /area/security/brig)
 "vcc" = (
@@ -51975,9 +51933,6 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "vwd" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -51995,6 +51950,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Prison Wing"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "vwp" = (
@@ -53059,9 +53017,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vXP" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53074,6 +53029,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/machinery/door/airlock/hop{
+	name = "Head of Personnel's Office"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "vXW" = (
@@ -53186,9 +53144,6 @@
 /turf/open/floor/iron/freezer,
 /area/medical/virology)
 "waU" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -53197,6 +53152,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Brig Control"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "wbr" = (
@@ -55126,11 +55084,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance-right"
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/airlock/security/old/glass{
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron,
 /area/security/brig)
 "wQU" = (
@@ -55172,7 +55130,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "wRV" = (
 /obj/effect/turf_decal/tile/red,
@@ -55836,9 +55794,6 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "xgm" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -55851,6 +55806,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/old/glass{
+	name = "Prison Wing"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "xgt" = (
@@ -57873,10 +57831,6 @@
 /turf/open/floor/iron,
 /area/security/office)
 "ydr" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Crematorium"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -57884,6 +57838,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
+/obj/machinery/door/airlock/security/old{
+	name = "Crematorium"
+	},
 /turf/open/floor/iron/dark,
 /area/security/processing/cremation)
 "ydH" = (
@@ -75868,12 +75825,12 @@ aaa
 aaa
 aaa
 aaa
-afU
-afU
+aiA
+aiA
 uqJ
 uqJ
-afU
-aiu
+aiA
+xFH
 ajG
 akv
 alj
@@ -76121,16 +76078,16 @@ wOG
 aOn
 aaa
 aaa
-afU
+aiA
 agi
 agi
 agi
-afU
+aiA
 hwj
 nbp
 ueB
 whk
-aiu
+xFH
 ajG
 akv
 alk
@@ -76378,7 +76335,7 @@ fUJ
 aOn
 aOn
 aOn
-afU
+aiA
 uME
 sOC
 iCV
@@ -76387,7 +76344,7 @@ dVI
 sAy
 nMh
 uSC
-aiu
+xFH
 ajG
 nMb
 ajD
@@ -76644,12 +76601,12 @@ ddE
 bvN
 bvN
 gqr
-aiu
-aiu
-aiu
-aiu
-aiu
-aiu
+xFH
+xFH
+xFH
+xFH
+xFH
+xFH
 ueU
 aiu
 aiu
@@ -76902,7 +76859,7 @@ ahy
 gXr
 jlY
 pjA
-ajH
+mLe
 akx
 alY
 wtj
@@ -77163,7 +77120,7 @@ ydr
 wtj
 wtj
 moT
-aiu
+xFH
 aiu
 ueU
 aiu
@@ -79744,7 +79701,7 @@ eci
 ajM
 ajM
 ajM
-ajM
+akA
 lQY
 aUB
 sMU
@@ -80772,7 +80729,7 @@ cXT
 ajM
 ajM
 ajM
-ajM
+akA
 iQD
 edm
 nsA
@@ -81800,7 +81757,7 @@ mqk
 ajM
 ajM
 ajM
-ajM
+akA
 mHm
 edm
 nYj
@@ -82034,7 +81991,7 @@ aaa
 aaa
 dUd
 abI
-rly
+lcA
 xLq
 ahL
 ahL
@@ -82054,7 +82011,7 @@ amg
 oHF
 kth
 iNC
-mLe
+vbM
 qcL
 djB
 vbM
@@ -82291,7 +82248,7 @@ aaa
 aaa
 dUd
 aaa
-rly
+lcA
 wsJ
 eAe
 rNf
@@ -83319,7 +83276,7 @@ aaa
 aaa
 dUd
 abI
-rly
+lcA
 pvL
 ttb
 vDY
@@ -84347,7 +84304,7 @@ aaa
 aaa
 dUd
 aaa
-rly
+lcA
 lle
 szU
 lzA
@@ -84355,13 +84312,13 @@ lzA
 eMv
 rly
 ajr
-aiR
+ajs
 qQn
-aiR
+ajs
 pSR
-aiR
+ajs
 qQn
-aoz
+aqF
 api
 aoz
 aal
@@ -84604,21 +84561,21 @@ aaa
 aaa
 dUd
 abI
-rly
+lcA
 gsa
 szU
 jkr
 cjN
-rly
+lcA
 otm
 ajs
-aiR
+ajs
 aeL
 cxV
 ptm
 cxV
 kOn
-aoz
+aqF
 api
 aoz
 tJP
@@ -84861,12 +84818,12 @@ aaa
 aaa
 aaa
 aaa
-rly
+lcA
 ooO
 ooO
 ooO
-rly
-rly
+lcA
+lcA
 abI
 ajs
 azi
@@ -84875,7 +84832,7 @@ unQ
 dFy
 fzt
 dcm
-aoz
+aqF
 api
 aoz
 awj
@@ -85132,7 +85089,7 @@ ltp
 bjz
 qDF
 nnu
-aoz
+aqF
 api
 aoz
 avN
@@ -85389,7 +85346,7 @@ jph
 wXf
 onp
 wnG
-aoz
+aqF
 uHp
 aoz
 aoz
@@ -85646,7 +85603,7 @@ fzt
 hxm
 fzt
 kGJ
-aoz
+aqF
 apk
 qbH
 fvq
@@ -96752,7 +96709,7 @@ bnT
 nEZ
 gMe
 qhX
-lcA
+bkx
 tOJ
 bvM
 nBG
@@ -101374,8 +101331,8 @@ lru
 aFi
 sot
 vxp
-boc
-eNo
+bky
+bky
 vrE
 moB
 ebL
@@ -101631,7 +101588,7 @@ lru
 aEj
 iSi
 iSi
-tno
+iSi
 iSi
 iSi
 brR
@@ -102143,7 +102100,7 @@ tfz
 mdx
 fGd
 aKq
-jHp
+aFi
 tHX
 rpa
 rpa
@@ -102400,7 +102357,7 @@ uma
 iSi
 iSi
 iSi
-tno
+iSi
 iSi
 iSi
 iSi

--- a/jollystation_modules/code/game/machinery/doors/airlock.dm
+++ b/jollystation_modules/code/game/machinery/doors/airlock.dm
@@ -247,8 +247,18 @@
 /obj/machinery/door/airlock/captain
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/cap.dmi'
 
+/obj/machinery/door/airlock/captain/glass
+	opacity = FALSE
+	glass = TRUE
+	normal_integrity = 400
+
 /obj/machinery/door/airlock/hop
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/hop.dmi'
+
+/obj/machinery/door/airlock/hop/glass
+	opacity = FALSE
+	glass = TRUE
+	normal_integrity = 400
 
 /obj/machinery/door/airlock/hos
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/hos.dmi'


### PR DESCRIPTION
All this does is add new doors to Pubby and Lima via our new aesthetics. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
add: Pubby and Lima now use some new doors for certain command areas.
fix: Lima HoP fax machine was moved to make the table more accessible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
