### PR TITLE
// NON-MODULAR CHANGES: Felinid Replacement

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -9,6 +9,8 @@
 		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
 	mutant_bodyparts = list("tail_human" = "None", "ears" = "None", "wings" = "None")
+	mutantears = /obj/item/organ/ears
+	mutant_organs = list()
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW | CLOTH
@@ -16,10 +18,58 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1
 
+//Curiosity killed the human's wagging tail.
+/datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
+	if(H)
+		stop_wagging_tail(H)
+
+/datum/species/human/spec_stun(mob/living/carbon/human/H,amount)
+	if(H)
+		stop_wagging_tail(H)
+	. = ..()
+
+/datum/species/human/can_wag_tail(mob/living/carbon/human/H)
+	return mutant_bodyparts["tail_human"] || mutant_bodyparts["waggingtail_human"]
+
+/datum/species/human/is_wagging_tail(mob/living/carbon/human/H)
+	return mutant_bodyparts["waggingtail_human"]
+
+/datum/species/human/start_wagging_tail(mob/living/carbon/human/H)
+	if(mutant_bodyparts["tail_human"])
+		mutant_bodyparts["waggingtail_human"] = mutant_bodyparts["tail_human"]
+		mutant_bodyparts -= "tail_human"
+	H.update_body()
+
+/datum/species/human/stop_wagging_tail(mob/living/carbon/human/H)
+	if(mutant_bodyparts["waggingtail_human"])
+		mutant_bodyparts["tail_human"] = mutant_bodyparts["waggingtail_human"]
+		mutant_bodyparts -= "waggingtail_human"
+	H.update_body()
+
+/datum/species/human/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		if(H.dna.features["ears"] == "Cat")
+			var/obj/item/organ/ears/cat/ears = new
+			ears.Insert(H, drop_if_replaced = FALSE)
+		else
+			mutantears = /obj/item/organ/ears
+		if(H.dna.features["tail_human"] == "Cat")
+			var/obj/item/organ/tail/cat/tail = new
+			tail.Insert(H, special = TRUE, drop_if_replaced = FALSE)
+		else
+			mutant_organs = list()
+	return ..()
+
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.hairstyle = "Business Hair"
 	human.hair_color = "#bb9966" // brown
 	human.update_hair()
+
+	var/obj/item/organ/ears/cat/cat_ears = human.getorgan(/obj/item/organ/ears/cat)
+	if (cat_ears)
+		cat_ears.color = human.hair_color
+		human.update_body()
 
 /datum/species/human/get_scream_sound(mob/living/carbon/human/human)
 	if(human.gender == MALE)

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -8,7 +8,7 @@
 		TRAIT_CAN_STRIP,
 		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
-	mutant_bodyparts = list("wings" = "None")
+	mutant_bodyparts = list("tail_human" = "None", "ears" = "None", "wings" = "None")
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW | CLOTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/58570888/166754086-f2639225-fdbd-4826-bfe0-5bec6cadb172.png)

TODO

- [ ] Make humans able to select cat ears and tail
- [ ] Add a checkbox that makes them nonhuman to do so
- [ ] make them work with laserpointers/other isfelinid() checks
- [ ] port tarajans

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How does it improve JollyStation
It adds something Jolly wants added
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Bondismyname but I wish it wasnt
add: I will update this when the code is more written
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
