### PR TITLE
Changes some VSCode options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,6 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": {
-		"*.dmi": "imagePreview.previewEditor"
-	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,
 	"gitlens.advanced.blame.customArguments": ["-w"],


### PR DESCRIPTION
Contributors should get https://marketplace.visualstudio.com/items?itemName=AnturK.dmi-editor for any .DMI related stuff.

Don't know if this'll break the editor trying to look at .DMIs right now, but you should get it.