### PR TITLE
Port-A-Fix (Door fixes)

### DIFF
--- a/jollystation_modules/code/game/machinery/doors/airlock.dm
+++ b/jollystation_modules/code/game/machinery/doors/airlock.dm
@@ -381,8 +381,8 @@
 //ASSEMBLYS
 
 /obj/structure/door_assembly/
-	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/public.dmi'
-	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/overlays.dmi'
+	icon = 'jollystation_modules/icons/obj/doors/airlocks/station/public.dmi'
+	overlays_file = 'jollystation_modules/icons/obj/doors/airlocks/station/overlays.dmi'
 
 
 /obj/structure/door_assembly/door_assembly_public

--- a/jollystation_modules/code/game/machinery/doors/airlock.dm
+++ b/jollystation_modules/code/game/machinery/doors/airlock.dm
@@ -379,6 +379,12 @@
 	overlays_file = 'jollystation_modules/icons/obj/doors/airlocks/multi_tile/overlays.dmi'
 
 //ASSEMBLYS
+
+/obj/structure/door_assembly/
+	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/public.dmi'
+	overlays_file = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/station/overlays.dmi'
+
+
 /obj/structure/door_assembly/door_assembly_public
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/station2/glass.dmi'
 	overlays_file = 'jollystation_modules/icons/obj/doors/airlocks/station2/overlays.dmi'

--- a/jollystation_modules/code/game/machinery/doors/airlock.dm
+++ b/jollystation_modules/code/game/machinery/doors/airlock.dm
@@ -246,6 +246,7 @@
 
 /obj/machinery/door/airlock/captain
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/cap.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_captain
 
 /obj/machinery/door/airlock/captain/glass
 	opacity = FALSE
@@ -254,6 +255,7 @@
 
 /obj/machinery/door/airlock/hop
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/hop.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_hop
 
 /obj/machinery/door/airlock/hop/glass
 	opacity = FALSE
@@ -262,6 +264,7 @@
 
 /obj/machinery/door/airlock/hos
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/hos.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_hos
 
 /obj/machinery/door/airlock/hos/glass
 	opacity = FALSE
@@ -270,6 +273,7 @@
 
 /obj/machinery/door/airlock/ce
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/ce.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_ce
 
 /obj/machinery/door/airlock/ce/glass
 	opacity = FALSE
@@ -278,6 +282,7 @@
 
 /obj/machinery/door/airlock/rd
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/rd.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_rd
 
 /obj/machinery/door/airlock/rd/glass
 	opacity = FALSE
@@ -286,6 +291,7 @@
 
 /obj/machinery/door/airlock/qm
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/qm.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_qm
 
 /obj/machinery/door/airlock/qm/glass
 	opacity = FALSE
@@ -294,6 +300,7 @@
 
 /obj/machinery/door/airlock/cmo
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/cmo.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_cmo
 
 /obj/machinery/door/airlock/cmo/glass
 	opacity = FALSE
@@ -302,12 +309,15 @@
 
 /obj/machinery/door/airlock/psych
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/psych.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_psych
 
 /obj/machinery/door/airlock/asylum
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/asylum.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_asylum
 
 /obj/machinery/door/airlock/bathroom
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/bathroom.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_bathroom
 
 //STATION MINERAL AIRLOCKS
 /obj/machinery/door/airlock/gold
@@ -448,7 +458,6 @@
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/vault/vault.dmi'
 	overlays_file = 'jollystation_modules/icons/obj/doors/airlocks/vault/overlays.dmi'
 
-
 /obj/structure/door_assembly/door_assembly_centcom
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/centcom/centcom.dmi'
 	overlays_file = 'jollystation_modules/icons/obj/doors/airlocks/centcom/overlays.dmi'
@@ -506,7 +515,7 @@
 	glass_type = /obj/machinery/door/airlock/command/glass
 	airlock_type = /obj/machinery/door/airlock/hop
 
-/obj/structure/door_assembly/hos
+/obj/structure/door_assembly/door_assembly_hos
 	name = "head of security airlock assembly"
 	icon = 'jollystation_modules/icons/obj/doors/airlocks/hos.dmi'
 	glass_type = /obj/machinery/door/airlock/hos/glass


### PR DESCRIPTION
Ports the fix from https://github.com/Skyrat-SS13/Skyrat-tg/pull/13775

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Deek-Za, Jolly
fix: Public assembly airlocks now use our door icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
