### PR TITLE
Re-Adds flora to Lima

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -295,6 +295,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/science/lab)
 "aiw" = (
@@ -496,6 +497,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"alq" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "alC" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -827,6 +835,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ash" = (
@@ -1287,7 +1296,8 @@
 	dir = 1
 	},
 /obj/structure/window,
-/obj/structure/flora/bush,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/security/detectives_office/bridge_officer_office)
 "aDd" = (
@@ -1365,6 +1375,8 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "aFp" = (
@@ -1668,6 +1680,7 @@
 /area/station/security/prison/safe)
 "aMV" = (
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "aMW" = (
@@ -1970,13 +1983,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"aUh" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/flora/grass/brown,
-/turf/open/floor/grass,
-/area/station/hallway/secondary/exit/departure_lounge)
 "aUi" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -2038,6 +2044,13 @@
 	name = "black plastitanium floor"
 	},
 /area/station/service/bar)
+"aVE" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/command/bridge)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2100,6 +2113,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_br,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/command)
 "aWY" = (
@@ -2404,6 +2418,7 @@
 /area/station/service/bar)
 "bcg" = (
 /obj/machinery/door/window/right/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "bck" = (
@@ -4767,6 +4782,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"bZl" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "bZm" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5025,6 +5044,8 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/aft)
 "cfj" = (
@@ -5082,6 +5103,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
+"cfZ" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "cgi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -5593,6 +5621,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
 "ctv" = (
@@ -6024,6 +6053,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"czq" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "czv" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -6482,6 +6519,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
+"cLf" = (
+/obj/machinery/light/directional/south,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "cLu" = (
 /obj/structure/chair,
 /obj/machinery/camera{
@@ -6530,6 +6572,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"cMM" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_pp,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/command)
 "cMQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -7295,6 +7344,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
+/obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "dbH" = (
@@ -7347,6 +7397,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "dbT" = (
@@ -7906,6 +7958,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "dmi" = (
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "dmv" = (
@@ -8917,6 +8970,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/station/hallway/primary/central)
+"dIm" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "dIo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -9387,6 +9444,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"dSn" = (
+/obj/structure/window,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/command)
 "dSp" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/royalblue,
@@ -9474,6 +9539,17 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/library)
+"dTP" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dUl" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -10032,6 +10108,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lower)
+"ejJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "ejK" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4;
@@ -10166,6 +10250,13 @@
 	icon_state = "wood-broken"
 	},
 /area/station/maintenance/starboard/aft)
+"emi" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "ems" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
@@ -10354,6 +10445,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
+"eqP" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "era" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "O2 to Secondary Mix"
@@ -10696,6 +10798,15 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"exC" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "exN" = (
 /obj/structure/chair/plastic,
 /obj/structure/window/reinforced{
@@ -10931,6 +11042,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"eBF" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eCp" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
@@ -11520,6 +11638,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "eLx" = (
@@ -11569,6 +11688,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "eMN" = (
@@ -11633,6 +11753,9 @@
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central)
 "eNK" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eOa" = (
@@ -11855,6 +11978,14 @@
 	icon_state = "panelscorched"
 	},
 /area/station/maintenance/department/engine/atmos)
+"eRw" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eRE" = (
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
@@ -11918,6 +12049,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "eSR" = (
@@ -12567,6 +12699,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/security/detectives_office/bridge_officer_office)
 "feT" = (
@@ -12978,6 +13111,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"fna" = (
+/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "fnd" = (
 /obj/structure/window{
 	dir = 4
@@ -13156,7 +13294,8 @@
 /area/station/hallway/primary/upper)
 "fqR" = (
 /obj/structure/window,
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/leafy,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "fqY" = (
@@ -13958,6 +14097,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"fGM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "fGS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -14129,6 +14275,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fJT" = (
@@ -14968,6 +15116,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos/upper)
+"fYR" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "fYS" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom/directional/east,
@@ -15041,6 +15193,14 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"fZW" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/medical/patients_rooms)
 "fZZ" = (
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
@@ -15226,6 +15386,9 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gfN" = (
@@ -16076,6 +16239,7 @@
 	},
 /obj/structure/window,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gwq" = (
@@ -17179,6 +17343,8 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/aft)
 "gQT" = (
@@ -17871,6 +18037,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel)
+"hdl" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "hdm" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -18433,6 +18606,8 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/leafy,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "hnp" = (
@@ -18444,8 +18619,8 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/abandoned)
 "hnE" = (
-/obj/structure/flora/grass/jungle/b,
 /obj/machinery/door/window/left/directional/west,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "hnH" = (
@@ -19440,8 +19615,8 @@
 /turf/open/floor/carpet/cyan,
 /area/station/hallway/primary/port)
 "hKa" = (
-/obj/structure/flora/grass/brown,
 /obj/machinery/light/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hKi" = (
@@ -20153,7 +20328,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "hYW" = (
-/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "hYY" = (
@@ -20364,6 +20539,11 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"icC" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "icF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -20594,6 +20774,7 @@
 	dir = 8
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "ihn" = (
@@ -21463,6 +21644,7 @@
 	dir = 1
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/security/detectives_office/bridge_officer_office)
 "iAc" = (
@@ -21484,10 +21666,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "iAr" = (
-/obj/structure/flora/grass/green,
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "iAv" = (
@@ -21868,6 +22050,8 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
 "iIu" = (
@@ -21891,6 +22075,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"iII" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "iIL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -23922,6 +24113,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/research)
 "jxh" = (
@@ -24236,6 +24428,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "jDo" = (
@@ -24705,6 +24898,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "jMa" = (
@@ -25398,6 +25592,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/assistant,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jZE" = (
@@ -26275,6 +26470,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"knA" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/closed/wall,
+/area/station/maintenance/department/electrical)
 "knF" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -27131,6 +27330,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/command)
 "kDS" = (
@@ -27412,6 +27612,20 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
+"kKS" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bo";
+	name = "Privacy Shutters"
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/security/detectives_office/bridge_officer_office)
 "kLe" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -27603,6 +27817,8 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/bush/flowers_br,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/command)
 "kPo" = (
@@ -28205,7 +28421,7 @@
 /obj/structure/window{
 	dir = 1
 	},
-/obj/structure/flora/grass/green,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "lac" = (
@@ -28247,6 +28463,7 @@
 	dir = 8
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "lay" = (
@@ -28280,6 +28497,14 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/royalblack,
 /area/station/security/detectives_office/bridge_officer_office)
+"lbk" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "lbr" = (
 /obj/machinery/light/small/red/directional/east,
 /obj/effect/spawner/random/structure/crate,
@@ -28963,6 +29188,17 @@
 	dir = 4
 	},
 /area/station/security/courtroom)
+"lly" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "llI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29317,6 +29553,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
 "lsB" = (
@@ -31202,6 +31439,7 @@
 "mdy" = (
 /obj/machinery/light/directional/south,
 /mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "mdK" = (
@@ -31212,6 +31450,7 @@
 /area/station/engineering/engine_smes)
 "mdQ" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "mec" = (
@@ -31286,6 +31525,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "mfj" = (
@@ -32375,6 +32615,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "myq" = (
@@ -32387,6 +32628,7 @@
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/door/window/left/directional/east,
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "myx" = (
@@ -32598,7 +32840,7 @@
 /obj/structure/window{
 	dir = 4
 	},
-/obj/structure/flora/bush,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "mCd" = (
@@ -33212,6 +33454,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "mPu" = (
@@ -33561,6 +33804,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "mVz" = (
@@ -34326,6 +34570,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/security/courtroom)
 "njZ" = (
@@ -34578,6 +34824,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "noK" = (
@@ -35413,6 +35661,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"nEJ" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nEP" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -35682,6 +35935,7 @@
 	dir = 8
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "nIo" = (
@@ -35726,6 +35980,10 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/cryo)
+"nIW" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "nIY" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 8
@@ -35991,6 +36249,7 @@
 	dir = 1
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "nNh" = (
@@ -36014,6 +36273,8 @@
 	dir = 1
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "nNy" = (
@@ -36084,6 +36345,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"nPP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "nPU" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -36098,6 +36366,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"nQK" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "nQR" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
@@ -36539,6 +36814,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "oaK" = (
@@ -36767,7 +37043,7 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ofQ" = (
-/obj/structure/flora/grass/green,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "ofW" = (
@@ -37594,6 +37870,8 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/aft)
 "oum" = (
@@ -38108,6 +38386,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "oEw" = (
@@ -38158,6 +38437,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "oFy" = (
@@ -38388,6 +38668,7 @@
 /area/station/security/prison)
 "oJQ" = (
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/command)
 "oJT" = (
@@ -38506,6 +38787,7 @@
 /obj/structure/window,
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/light/warm/directional/north,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "oMz" = (
@@ -38778,6 +39060,8 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "oSC" = (
@@ -39183,6 +39467,13 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"oZY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "pai" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -39358,6 +39649,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/station/maintenance/department/crew_quarters/dorms)
+"pdq" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "pdz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40021,6 +40316,7 @@
 	dir = 8
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pqZ" = (
@@ -40580,6 +40876,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"pCD" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "pCR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -41000,6 +41300,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/security/detectives_office/bridge_officer_office)
 "pJJ" = (
@@ -41613,6 +41914,7 @@
 	dir = 9
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "pVo" = (
@@ -41681,6 +41983,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"pWR" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/chapel)
 "pXd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/purple{
@@ -41976,6 +42285,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"qbT" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/science/research)
 "qci" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42908,6 +43225,14 @@
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"qtS" = (
+/obj/structure/window,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/command)
 "quh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -43641,6 +43966,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "qHy" = (
@@ -43707,6 +44034,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/sepia,
 /area/station/service/chapel/office)
+"qJt" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qJv" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -44474,13 +44810,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"qXQ" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "qXZ" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -44765,6 +45094,7 @@
 "rcR" = (
 /obj/machinery/light/directional/north,
 /mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "rcX" = (
@@ -44805,6 +45135,7 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/science/research)
 "rds" = (
@@ -45870,6 +46201,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"rxX" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rxZ" = (
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/plating,
@@ -46073,6 +46412,7 @@
 	name = "Monkey Pen";
 	req_one_access_txt = "9;40"
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "rCI" = (
@@ -46543,6 +46883,14 @@
 	dir = 4
 	},
 /area/station/engineering/main)
+"rMj" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "rMz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering-Atmospherics Connection"
@@ -46843,6 +47191,7 @@
 /obj/machinery/newscaster/directional/west,
 /obj/structure/flora/tree/jungle/small,
 /obj/machinery/light/directional/west,
+/obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "rSy" = (
@@ -46983,6 +47332,13 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"rUj" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/command/bridge)
 "rUt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47645,6 +48001,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "sfh" = (
@@ -47775,6 +48132,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "siH" = (
@@ -48050,6 +48408,13 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lower)
+"smH" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "smR" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -48088,6 +48453,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"sog" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "soq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48346,6 +48715,10 @@
 	icon_state = "panelscorched"
 	},
 /area/station/maintenance/starboard/lower)
+"ssr" = (
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "ssv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48533,6 +48906,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "swA" = (
@@ -48605,6 +48979,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sxB" = (
@@ -48805,6 +49180,7 @@
 	dir = 4
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "sBs" = (
@@ -49974,6 +50350,7 @@
 	dir = 4
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sUK" = (
@@ -50436,6 +50813,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/genetics)
+"tef" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tes" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -50844,6 +51228,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"tmQ" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/security/courtroom)
 "tmV" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -51596,6 +51987,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
+"tCJ" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/science/research)
 "tCY" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/crate,
@@ -51767,6 +52165,7 @@
 /area/station/security/execution/education)
 "tGa" = (
 /obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "tGi" = (
@@ -51890,6 +52289,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/service/abandoned_gambling_den)
+"tIX" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "tJd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52810,6 +53213,7 @@
 	dir = 1
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "ube" = (
@@ -53392,6 +53796,9 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uoh" = (
@@ -53535,6 +53942,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "uqh" = (
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "uqm" = (
@@ -54089,6 +54497,7 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "uBf" = (
@@ -54425,6 +54834,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"uJc" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uJk" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -54527,6 +54943,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"uLd" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/secondary/command)
 "uLe" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -54987,6 +55411,7 @@
 	dir = 4
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "uTG" = (
@@ -55040,6 +55465,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "uUJ" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "uUN" = (
@@ -55121,6 +55548,7 @@
 	},
 /obj/machinery/status_display/evac/directional/south,
 /obj/machinery/light/warm/directional/south,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "uWy" = (
@@ -55186,6 +55614,13 @@
 /obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"uXS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "uXV" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -55963,6 +56398,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "voA" = (
@@ -57416,6 +57852,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "vTG" = (
@@ -58395,6 +58832,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/park)
 "wlM" = (
@@ -59060,6 +59498,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "wzq" = (
@@ -59646,6 +60086,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"wLK" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/upper)
 "wLL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -59896,6 +60343,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "wRs" = (
@@ -60375,6 +60824,7 @@
 	id = "rnd";
 	name = "Research Lab Shutters"
 	},
+/obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/station/science/lab)
 "xdf" = (
@@ -60438,6 +60888,7 @@
 	id = "rnd";
 	name = "Research Lab Shutters"
 	},
+/obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/station/science/lab)
 "xeD" = (
@@ -60614,6 +61065,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "xhs" = (
@@ -60683,6 +61136,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"xjk" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "xju" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
@@ -60854,7 +61314,7 @@
 /obj/structure/window{
 	dir = 4
 	},
-/obj/structure/flora/grass/green,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/chapel)
 "xom" = (
@@ -61314,6 +61774,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"xvA" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "xvF" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Aux Chamber";
@@ -61450,6 +61915,20 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"xyH" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bo";
+	name = "Privacy Shutters"
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/security/detectives_office/bridge_officer_office)
 "xyI" = (
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
@@ -61898,6 +62377,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/secondary/service)
+"xHs" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/park)
 "xHB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -62321,16 +62807,6 @@
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"xQl" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/flora/grass/green,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics)
 "xQq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62368,6 +62844,7 @@
 /obj/item/toy/plush/snakeplushie{
 	desc = "An adorable stuffed toy that resembles a snake. He's trapped. Free him."
 	},
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "xQN" = (
@@ -62601,6 +63078,8 @@
 	pixel_y = 1
 	},
 /obj/structure/window/reinforced,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "xUH" = (
@@ -63132,6 +63611,7 @@
 	dir = 1
 	},
 /obj/structure/window,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "yeB" = (
@@ -63397,6 +63877,8 @@
 /obj/structure/window{
 	dir = 1
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ykw" = (
@@ -85437,7 +85919,7 @@ kaT
 eeM
 tjQ
 erw
-ctu
+tmQ
 fXe
 hNi
 cSk
@@ -85951,7 +86433,7 @@ pwA
 aWp
 nEE
 pMY
-ctu
+tmQ
 fXe
 hNi
 cSk
@@ -87463,7 +87945,7 @@ ydd
 irT
 bZZ
 hvK
-eSP
+nQK
 mQQ
 ljS
 agD
@@ -87720,7 +88202,7 @@ aKC
 roS
 bZZ
 nay
-eSP
+pWR
 mQQ
 kRI
 dXy
@@ -87977,7 +88459,7 @@ hQO
 hQO
 bZZ
 wmR
-qXQ
+eSP
 mQQ
 mQQ
 uWY
@@ -88758,7 +89240,7 @@ vHZ
 uzm
 kXt
 bcg
-oFu
+czq
 xod
 uBc
 oFu
@@ -90814,8 +91296,8 @@ oit
 hdc
 kXt
 hnE
-jLY
-mVl
+lbk
+hdl
 mVl
 jLY
 uqh
@@ -92890,7 +93372,7 @@ qvO
 qvO
 jep
 ofQ
-swv
+rMj
 myw
 gXJ
 piL
@@ -92898,7 +93380,7 @@ piL
 qyc
 myp
 swv
-kIr
+bZl
 hbV
 hzQ
 mge
@@ -94745,7 +95227,7 @@ tvX
 oBH
 oBH
 sxy
-vod
+emi
 vod
 pqF
 oBH
@@ -95459,7 +95941,7 @@ pCn
 mgB
 qvO
 jep
-xQl
+eLu
 oaF
 uTr
 usr
@@ -95779,8 +96261,8 @@ mtZ
 oBH
 vas
 pum
-yki
-eNK
+alq
+nEJ
 szD
 xzK
 xzK
@@ -96036,7 +96518,7 @@ gwm
 jdT
 dQx
 pum
-yki
+tef
 hKa
 szD
 xzK
@@ -96293,8 +96775,8 @@ kHk
 itE
 itE
 ebO
-yki
-eNK
+eRw
+nIW
 szD
 xzK
 xzK
@@ -96511,7 +96993,7 @@ kCy
 kCy
 kCy
 kCy
-hno
+wLK
 hno
 lat
 iKd
@@ -96550,7 +97032,7 @@ fqp
 oBH
 oBH
 ebO
-aUh
+alq
 eNK
 szD
 xzK
@@ -96752,7 +97234,7 @@ moo
 pJR
 ghF
 muu
-iSe
+fZW
 clv
 xqI
 hVB
@@ -96795,9 +97277,9 @@ lFt
 ciO
 rqp
 iak
-uog
+cfZ
 qnv
-oMr
+dTP
 vas
 cHn
 ooM
@@ -97057,9 +97539,9 @@ dIP
 hYv
 cKQ
 cHn
-sxy
-vod
-vod
+eqP
+smH
+rxX
 iEm
 oBH
 iUc
@@ -97266,7 +97748,7 @@ hek
 pJR
 hco
 wGv
-iSe
+fZW
 oOP
 onp
 hVB
@@ -97314,10 +97796,10 @@ dIP
 hYv
 oBH
 cHn
-fJQ
-uog
-uog
-sUz
+lly
+eBF
+qJt
+exC
 oBH
 oBH
 quZ
@@ -97823,7 +98305,7 @@ cIg
 rqp
 xbs
 iak
-vod
+uJc
 qnv
 asg
 cHn
@@ -98579,8 +99061,8 @@ ris
 ris
 ris
 ris
-kPl
-kPl
+cMM
+uLd
 kPl
 aWN
 oqB
@@ -101923,7 +102405,7 @@ chZ
 xAF
 sgG
 ora
-aWN
+dSn
 mEk
 ari
 lZo
@@ -102180,7 +102662,7 @@ ora
 ora
 mJS
 ora
-kDD
+qtS
 oqB
 ari
 hfd
@@ -102955,7 +103437,7 @@ eMb
 eMb
 lNL
 lZo
-mPh
+rUj
 aRh
 vAo
 ddg
@@ -103206,13 +103688,13 @@ bhg
 nHz
 nHz
 nHz
-pJz
-pJz
+xyH
+kKS
 pJz
 feR
 wfu
 lZo
-mPh
+aVE
 xhr
 pHb
 aNE
@@ -105522,7 +106004,7 @@ blx
 djg
 was
 csg
-maU
+knA
 xzK
 xzK
 xzK
@@ -107287,8 +107769,8 @@ fVo
 uLl
 qaU
 rdp
-jxf
-jxf
+qbT
+tCJ
 jxf
 vzB
 vzB
@@ -110877,7 +111359,7 @@ wka
 wka
 dJc
 oEu
-jDe
+iII
 rCD
 jDe
 eMK
@@ -111134,8 +111616,8 @@ ftb
 kOg
 dJc
 rcR
-uUJ
-uUJ
+tIX
+xjk
 uUJ
 mdy
 dWZ
@@ -111391,10 +111873,10 @@ wka
 wka
 dJc
 bFZ
-uUJ
-uUJ
-uUJ
-bFZ
+pdq
+pdq
+ssr
+fna
 dWZ
 fPz
 sAV
@@ -157644,14 +158126,14 @@ piN
 dDJ
 qnp
 sag
-oFb
-cLX
+sog
+oZY
 teI
 teI
 teI
 teI
-lma
-oFb
+fGM
+pCD
 kcd
 sag
 aNg
@@ -157902,15 +158384,15 @@ aDd
 rim
 sag
 kcd
-oFb
+sog
 cLX
 vPz
 teI
 teI
-dgJ
+uXS
 iZK
-oFb
-oFb
+dIm
+sog
 aNg
 bJN
 siR
@@ -158166,7 +158648,7 @@ teI
 teI
 bwi
 oFb
-oFb
+pCD
 qTO
 aNg
 ueJ
@@ -158421,10 +158903,10 @@ nAW
 tGa
 teI
 teI
-dgJ
+ejJ
 oFb
-oFb
-oFb
+sog
+sog
 aNg
 qSs
 vaA
@@ -159440,7 +159922,7 @@ pdh
 qmd
 aNK
 sag
-oFb
+pCD
 oFb
 oFb
 oFb
@@ -159452,7 +159934,7 @@ teI
 spx
 bwi
 oFb
-qTO
+cLf
 jep
 rdb
 rdb
@@ -159702,7 +160184,7 @@ iZK
 oFb
 oFb
 oFb
-tGa
+xvA
 iIv
 teI
 teI
@@ -159954,16 +160436,16 @@ cOO
 evK
 lLM
 sag
-oFb
-oFb
+sog
+pCD
 oFb
 kcd
 oFb
-oFb
+fYR
 hGM
 teI
 teI
-dgJ
+nPP
 oFb
 mtU
 ebZ
@@ -160213,11 +160695,11 @@ boV
 sag
 hkY
 rSd
-oFb
+sog
 oFb
 pEL
 oFb
-tGa
+xvA
 vPz
 teI
 dgJ
@@ -160726,15 +161208,15 @@ evK
 boV
 fVj
 sag
-oFb
+dIm
 oFb
 xXl
 eYL
-oFb
-tGa
+dIm
+icC
 teI
 teI
-dgJ
+xHs
 oFb
 eYL
 xXl


### PR DESCRIPTION
Added back the flora to Lima, since I was too lazy to do it during the repathing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
fix: LimaStation is now properly fertilized. The flowers have bloomed (again)!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
