### PR TITLE
Engineering + Atmos Tech EXP req tweaks

### DIFF
--- a/jollystation_modules/code/modules/jobs/exp_rep.dm
+++ b/jollystation_modules/code/modules/jobs/exp_rep.dm
@@ -5,7 +5,7 @@
 	exp_requirements = 2400
 
 /datum/job/atmospheric_technician
-	exp_requirements = 180
+	exp_requirements = 300
 	exp_required_type = EXP_TYPE_ENGINEERING
 	exp_granted_type = EXP_TYPE_ENGINEERING
 
@@ -127,8 +127,8 @@
 	exp_granted_type = EXP_TYPE_SUPPLY
 
 /datum/job/station_engineer
-	exp_requirements = 0
-	exp_required_type = EXP_TYPE_ENGINEERING
+	exp_requirements = 300
+	exp_required_type = EXP_TYPE_SERVICE
 	exp_granted_type = EXP_TYPE_ENGINEERING
 
 /datum/job/virologist


### PR DESCRIPTION
People are joining dead-pop and using engineer to rush griefing the server.
This puts an end to it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Jolly
balance: Atmos Tech & Engineer require 5 hours of gameplay to be unlocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
