### PR TITLE
Fixes cybernetic cat ears

### DIFF
--- a/jollystation_modules/code/modules/research/designs/medical_designs.dm
+++ b/jollystation_modules/code/modules/research/designs/medical_designs.dm
@@ -5,6 +5,6 @@
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 30
 	materials = list(/datum/material/iron = 250, /datum/material/glass = 400)
-	build_path = /obj/item/organ/ears/cat/cybernetic
+	build_path = /obj/item/organ/internal/ears/cat/cybernetic
 	category = list("Cybernetics", "Medical Designs")
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/jollystation_modules/code/modules/surgery/organs/ears.dm
+++ b/jollystation_modules/code/modules/surgery/organs/ears.dm
@@ -6,14 +6,14 @@
 	icon_state = "cyber_kitty"
 	damage_multiplier = 1.5 //slightly better than regular cat ears
 
-/obj/item/organ/ears/cat/cybernetic/Insert(mob/living/carbon/human/ear_owner, special = 0, drop_if_replaced = TRUE)
+/obj/item/organ/internal/ears/cat/cybernetic/Insert(mob/living/carbon/human/ear_owner, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(istype(ear_owner))
 		color = ear_owner.hair_color
 		ear_owner.dna.features["ears"] = ear_owner.dna.species.mutant_bodyparts["ears"] = "Cybernetic Cat"
 		ear_owner.update_body()
 
-/obj/item/organ/ears/cat/cybernetic/Remove(mob/living/carbon/human/ear_owner,  special = 0)
+/obj/item/organ/internal/ears/cat/cybernetic/Remove(mob/living/carbon/human/ear_owner,  special = 0)
 	..()
 	if(istype(ear_owner))
 		color = ear_owner.hair_color
@@ -21,7 +21,7 @@
 		ear_owner.dna.species.mutant_bodyparts -= "ears"
 		ear_owner.update_body()
 
-/obj/item/organ/ears/cat/cybernetic/emp_act(severity)
+/obj/item/organ/internal/ears/cat/cybernetic/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return


### PR DESCRIPTION
## About The Pull Request

``## WARNING: design /datum/design/cybernetic_ears/cat with icon 'icons/obj/surgery.dmi' missing state ''``

## Changelog

:cl:
fix: Cybernetic cat ears now have a proper icon and can be printed.
/:cl: