### PR TITLE
Fixes some job inconsistencies

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -4900,7 +4900,6 @@
 #include "jollystation_modules\code\modules\jobs\exp_rep.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\_job.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\asset_protection.dm"
-#include "jollystation_modules\code\modules\jobs\job_types\assistant.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\bridge_officer.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\lawyer.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\ordnance_tech.dm"

--- a/jollystation_modules/code/datums/id_trim/jobs.dm
+++ b/jollystation_modules/code/datums/id_trim/jobs.dm
@@ -62,7 +62,7 @@
 	minimal_access = list(ACCESS_MECH_SCIENCE, ACCESS_MINERAL_STOREROOM, ACCESS_ORDNANCE, ACCESS_ORDNANCE_STORAGE,
 					ACCESS_RESEARCH, ACCESS_SCIENCE)
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
-	job = /datum/job/ordnance_tech
+	job = /datum/job/scientist/ordnance_tech
 
 // Xenobiologist
 /datum/id_trim/job/xenobiologist
@@ -75,4 +75,4 @@
 	minimal_access = list(ACCESS_MECH_SCIENCE, ACCESS_MINERAL_STOREROOM, ACCESS_RESEARCH, ACCESS_SCIENCE, ACCESS_XENOBIOLOGY,
 					ACCESS_XENOBOTANY)
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
-	job = /datum/job/xenobiologist
+	job = /datum/job/scientist/xenobiologist

--- a/jollystation_modules/code/game/objects/items/locker_spawners.dm
+++ b/jollystation_modules/code/game/objects/items/locker_spawners.dm
@@ -60,12 +60,12 @@
 	spawned_locker_path = /obj/structure/closet/secure_closet/asset_protection
 	icon_state = "gangtool-blue"
 
-// XenoBiologist locker summoner
+// Xenobiologist locker summoner
 /obj/item/locker_spawner/xenobotany
 	name = "xenobotany equipment beacon"
 	desc = "A beacon handed out for upcoming xenobiologists being assigned to stations without proper \
 		accommodations made for their occupation. When used, drop-pods in a fully stocked locker of equipment \
 		for use when you want to overrun the station with kuduz, the botanist way."
-	requires_job_path = /datum/job/xenobiologist
+	requires_job_path = /datum/job/scientist
 	spawned_locker_path = /obj/structure/closet/secure_closet/xeno_botany
 	icon_state = "gangtool-purple"

--- a/jollystation_modules/code/modules/jobs/job_types/assistant.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/assistant.dm
@@ -1,5 +1,0 @@
-/datum/outfit/job/assistant/give_jumpsuit(mob/living/carbon/human/target)
-	if(!ispath(uniform, /obj/item/clothing/under/color/grey))
-		return
-
-	return ..()

--- a/jollystation_modules/code/modules/jobs/job_types/ordnance_tech.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/ordnance_tech.dm
@@ -1,36 +1,17 @@
 // -- Ordnance Tech job & outfit datum --
-/datum/job/ordnance_tech
-	title = "Ordnance Technician"
+/datum/job/scientist/ordnance_tech
+	title = JOB_ORDNANCE_TECH
 	description = "Complete your bomb in the first half hour of the \
 		shift, make the station shake repeatedly as you refine cores, \
 		then sit around as you have nothing else to do."
-	department_head = list(JOB_RESEARCH_DIRECTOR)
-	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 3
-	supervisors = SUPERVISOR_RD
-	selection_color = "#ffeeff"
-	exp_requirements = 300
-	exp_required_type = EXP_TYPE_SCIENCE
-	exp_granted_type = EXP_TYPE_SCIENCE
-
-//most likely can be subtyped later
+	//most likely can be subtyped later //too late
 
 	outfit = /datum/outfit/job/scientist/ordnance_tech
 	plasmaman_outfit = /datum/outfit/plasmaman/science
 
-	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_SCI
-
 	display_order = JOB_DISPLAY_ORDER_ORDNANCE_TECH
-	bounty_types = CIV_JOB_SCI
-
-	departments_list = list(
-		/datum/job_department/science,
-		)
-
-	family_heirlooms = list(/obj/item/toy/nuke)
-
 	mail_goodies = list(
 		/obj/item/analyzer = 50,
 		/obj/item/raw_anomaly_core/random = 15,
@@ -41,7 +22,6 @@
 		/obj/item/transfer_valve = 1,
 	)
 
-	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 	rpg_title = "Dwarven Miner"
 
 /datum/outfit/job/scientist/ordnance_tech
@@ -49,5 +29,5 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/toxic
 	uniform = /obj/item/clothing/under/rank/rnd/ordnance_tech
 	belt = /obj/item/modular_computer/tablet/pda/science/ordnance_tech
-	jobtype = /datum/job/ordnance_tech
+	jobtype = /datum/job/scientist/ordnance_tech
 	id_trim = /datum/id_trim/job/ordnance_tech

--- a/jollystation_modules/code/modules/jobs/job_types/research_director.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/research_director.dm
@@ -1,2 +1,6 @@
-/datum/job/research_director
-	family_heirlooms = list(/obj/item/book/manual/wiki/cytology, /obj/item/reagent_containers/glass/beaker)
+/datum/job/research_director/New()
+	. = ..()
+	family_heirlooms += list(
+		/obj/item/book/manual/wiki/cytology,
+		/obj/item/reagent_containers/glass/beaker/large,
+	)

--- a/jollystation_modules/code/modules/jobs/job_types/scientist.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/scientist.dm
@@ -1,3 +1,8 @@
 // -- Scientist changes --
 /datum/job/scientist
-	family_heirlooms = list(/obj/item/book/manual/wiki/cytology, /obj/item/reagent_containers/glass/beaker)
+	family_heirlooms = list(
+		/obj/item/book/manual/wiki/cytology,
+		/obj/item/reagent_containers/glass/beaker/large,
+		/obj/item/toy/plush/slimeplushie,
+		/obj/item/toy/nuke,
+	)

--- a/jollystation_modules/code/modules/jobs/job_types/xenobiologist.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/xenobiologist.dm
@@ -1,28 +1,15 @@
 // -- Xenobiologist job & outfit datum --
-/datum/job/xenobiologist
-	title = "Xenobiologist"
+/datum/job/scientist/xenobiologist
+	title = JOB_XENOBIOLOGIST
 	description = "Feed slimes all shift, never exit xenobiology for any reason. \
 		Leave after two hours as an unkillable god with an army of monsters."
-	department_head = list(JOB_RESEARCH_DIRECTOR)
-	faction = FACTION_STATION
 	total_positions = 2
 	spawn_positions = 3
-	supervisors = SUPERVISOR_RD
-	selection_color = "#ffeeff"
-	exp_requirements = 300
-	exp_required_type = EXP_TYPE_SCIENCE
-	exp_granted_type = EXP_TYPE_SCIENCE
 
 	outfit = /datum/outfit/job/scientist/xenobiologist
 	plasmaman_outfit = /datum/outfit/plasmaman/science
 
-	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_SCI
-
 	display_order = JOB_DISPLAY_ORDER_XENOBIOLOGIST
-	bounty_types = CIV_JOB_SCI
-
-	family_heirlooms = list(/obj/item/toy/plush/slimeplushie)
 
 	mail_goodies = list(
 		/obj/item/toy/plush/slimeplushie = 25,
@@ -39,19 +26,14 @@
 		/obj/item/slime_extract/oil = 1
 	)
 
-	departments_list = list(
-		/datum/job_department/science,
-		)
-
-	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
-	rpg_title = "Beast Tamer"
+	rpg_title = "Slime Rancher"
 
 /datum/outfit/job/scientist/xenobiologist
 	name = "Xenobiologist"
 	suit = /obj/item/clothing/suit/toggle/labcoat/xenobio
 	uniform = /obj/item/clothing/under/rank/rnd/xenobiologist
 	belt = /obj/item/modular_computer/tablet/pda/science/xenobiologist
-	jobtype = /datum/job/xenobiologist
+	jobtype = /datum/job/scientist/xenobiologist
 	id_trim = /datum/id_trim/job/xenobiologist
 
 /datum/outfit/job/scientist/xenobiologist/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request

Removes the Assistant hardcoded grey jumpsuits, just use the config.
Makes Ordnance technician and Xenobiologist a subtype of Scientist, so there's less copy pasting. Moves their heirlooms to all be together, because I thought it would be funny
Lets the RD get their old heirlooms too, on top of their new ones.
Rd/Scientist beaker heirloom was replaced with a large beaker (50u difference!!)

## How does it improve JollyStation

I find it funny that a Xenobiologist would have a toy nuke.

## Changelog


:cl:
balance: Xenobiologists, Ordnance Technicians, and Scientists now all share the same heirlooms, which has all been added together.
balance: Scientists and Research Directors now get large beakers instead of small ones as an heirloom.
/:cl:
