### PR TITLE
Removes the HoS as a Lawyer's head of staff

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -209,6 +209,5 @@
 
 // Supervisor
 #define SUPERVISOR_COMMAND "the Heads of Staff and the Captain"
-#define SUPERVISOR_HOP_HOS "the Head of Personnel and Security"
 
 //NON-MODULAR CHANGES END

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -4902,7 +4902,6 @@
 #include "jollystation_modules\code\modules\jobs\job_types\asset_protection.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\assistant.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\bridge_officer.dm"
-#include "jollystation_modules\code\modules\jobs\job_types\lawyer.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\ordnance_tech.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\research_director.dm"
 #include "jollystation_modules\code\modules\jobs\job_types\scientist.dm"

--- a/jollystation_modules/code/modules/jobs/job_types/lawyer.dm
+++ b/jollystation_modules/code/modules/jobs/job_types/lawyer.dm
@@ -1,4 +1,0 @@
-// -- Lawyer changes --
-/datum/job/lawyer
-	department_head = list(JOB_HEAD_OF_PERSONNEL, JOB_HEAD_OF_SECURITY)
-	supervisors = SUPERVISOR_HOP_HOS


### PR DESCRIPTION
## About The Pull Request

The Lawyer is a Service job, not a Security one.
There's no reason for the HoS to be able to boss a Lawyer around, because it just encourages them to kick them out if they argue against Security. Them being Service makes them trustworthy to clients, and makes Security treat them such as well. For better or worse.

## How does it improve JollyStation

Explained in the about section, honestly.
Lawyers are supposed to be fighting for justice, and being part of the Security department goes against that,

## Changelog

:cl:
balance: Lawyers are no longer part of Security.
/:cl:
